### PR TITLE
Add DIF-GH model (LIF-GH with dentritic interaction of bilinear form) 

### DIFF
--- a/common_header.h
+++ b/common_header.h
@@ -33,6 +33,7 @@ static const double Inf = std::numeric_limits<double>::infinity();
 static const double qNaN = std::numeric_limits<double>::quiet_NaN();
 
 typedef std::vector<double> TyArrVals;
+typedef std::vector<TyArrVals> TyMatVals;
 
 extern std::mt19937 rand_eng;
 double g_rand();

--- a/common_header.h
+++ b/common_header.h
@@ -1,6 +1,14 @@
 #ifndef HEADER_COMMON_HEADER
 #define HEADER_COMMON_HEADER
 
+
+/* YWS: 
+ * to disable warning of vs, caused by std::copy
+ * in single_neuron_dynamics.h:
+ * std::copy(dym_t, dym_t+n_var, dym_val);
+ */
+#pragma warning(disable : 4996) 
+
 #ifndef DEBUG
 #define NDEBUG  // disable assert() and disable checks in Eigen
 #endif
@@ -21,7 +29,7 @@
 using std::cout;
 using std::cerr;
 using std::endl;
-#undef NDEBUG
+
 #ifdef NDEBUG
 #define dbg_printf(...) ((void)0);
 #else

--- a/common_header.h
+++ b/common_header.h
@@ -21,7 +21,7 @@
 using std::cout;
 using std::cerr;
 using std::endl;
-
+#undef NDEBUG
 #ifdef NDEBUG
 #define dbg_printf(...) ((void)0);
 #else

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@ TODO:
    * add to Poisson event queue?
    * isomerisom of neurons in a network?
 */
+#pragma warning(disable : 4996)  
 
 #ifndef DEBUG
 #define NDEBUG  // disable assert() and disable checks in Eigen
@@ -939,6 +940,8 @@ int main(int argc, char *argv[])
        "Read parameters from path, in INI style.")
       ("force-spike-list", po::value<std::string>(),
        "Read force spike list.")
+	  ("alpha-coefficient", po::value<std::string>(),
+	   "Set alpha-coeffecient from path, needed for DIF model.")
   ;
   // filter?
 

--- a/neuron_population.h
+++ b/neuron_population.h
@@ -652,10 +652,10 @@ public:						 // It is defined in struct TyNeuronalDymState
 			// Inhibitory neuron fired
 			for (SparseMat::InnerIterator it(net, se.id); it; ++it) {
 				if (it.row() < n_E) {
-					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scei;
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 3 + se.id) += it.value() * scei; // YWSCHECK
 				}
 				else {
-					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scii;
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 3 + se.id) += it.value() * scii;
 				}
 			}
 		}
@@ -725,7 +725,7 @@ public:						 // It is defined in struct TyNeuronalDymState
 
 	const Ty_Neuron_Dym_Base * GetNeuronModel() const override
 	{
-		assert(0);
+		// YWSCHECK assert(0);
 		return &neuron_models[0];
 	}
 };

--- a/neuron_population.h
+++ b/neuron_population.h
@@ -723,9 +723,10 @@ public:						 // It is defined in struct TyNeuronalDymState
 		}
 	}
 
+	// to get inform of the neuron model in main.c
+	// NOTE that some varibles may not be homogeneous!
 	const Ty_Neuron_Dym_Base * GetNeuronModel() const override
 	{
-		// YWSCHECK assert(0);
 		return &neuron_models[0];
 	}
 };

--- a/neuron_population.h
+++ b/neuron_population.h
@@ -710,16 +710,16 @@ public:						 // It is defined in struct TyNeuronalDymState
 	void InjectPoissonE(int neuron_id) override
 	{
 		// Add Poisson input
-		dym_vals(neuron_id, TyNeu::id_gEPoisson) += arr_ps[neuron_id];
+		dym_vals(neuron_id, TyNeu::id_gEPoisson_s1) += arr_ps[neuron_id];
 	}
 
 	void InjectDeltaInput(int neuron_id, double strength) override
 	{
 		if (strength >= 0) {
-			dym_vals(neuron_id, TyNeu::id_gEPoisson) += strength;
+			dym_vals(neuron_id, TyNeu::id_gEPoisson_s1) += strength;
 		}
 		else {
-			dym_vals(neuron_id, TyNeu::id_gIPoisson) -= strength;
+			dym_vals(neuron_id, TyNeu::id_gIPoisson_s1) -= strength;
 		}
 	}
 

--- a/neuron_population.h
+++ b/neuron_population.h
@@ -554,4 +554,180 @@ public:
   }
 };
 
+
+// Base class for dentritic interact
+class NeuronPopulationBaseDendritic
+	:public NeuronPopulationBaseCommon
+{
+public:
+	using NeuronPopulationBaseCommon::alpha;
+
+
+
+	NeuronPopulationBaseDendritic(const TyNeuronalParams &_pm, int n_var)
+		:NeuronPopulationBaseCommon(_pm, n_var + _pm.n_total() * 4)  
+						// we need extra space  _pm.n_total() * 4 to store dentritic conductance
+	{
+		
+		assert(DIF_flag == true);
+	}
+
+
+//	TyMatVals& Get_alpha(int neuron_id) {
+//		return alpha[neuron_id];
+//	}
+
+	TyMatVals* Get_alpha_Ptr(int neuron_id) {
+		return &alpha[neuron_id];
+	}
+
+};
+
+// Population:  dentretic interaction considered, delta interact, no delay, no current input
+template<class TyNeu, class NBase = NeuronPopulationBaseDendritic>  // neuron model
+class NeuronPopulationDendriticDeltaInteractTemplate :
+	public NBase
+{
+public:						 // It is defined in struct TyNeuronalDymState
+	using NBase::StatePtr;   // Note YWS: If this class is to be inherited, do CHECK this
+							 //using NBase::GetGEIPtr;  // Get g_EI for one neuron, return a doule*, storing g_E_i(*n_total) and g_I_i(*n_total) continously
+	using NBase::Get_alpha_Ptr;
+	using NBase::time_in_refractory;
+	using NBase::n_E;
+	using NBase::n_I;
+	using NBase::n_total;
+	using NBase::net;
+	using NBase::scee;
+	using NBase::scei;
+	using NBase::scie;
+	using NBase::scii;
+	using NBase::arr_ps;
+	using NBase::dym_vals;
+
+	//TyNeu neuron_model; // One can access some (not static but infact static) functions via this instance
+
+	std::vector<TyNeu> neuron_models;
+
+	NeuronPopulationDendriticDeltaInteractTemplate(const TyNeuronalParams &_pm)
+		:NBase(_pm, TyNeu::n_var)
+	{
+		TyNeu _neuron_model;
+		_neuron_model.n_neu = _pm.n_total();
+		neuron_models.resize(_pm.n_total(), _neuron_model);
+		for (int i = 0; i < n_total(); i++) {
+			neuron_models[i].alpha = Get_alpha_Ptr(i);
+			neuron_models[i].n_neu = _pm.n_total();
+		}
+
+	}
+
+	void NoInteractDt(int neuron_id, double dt, double t_local,
+		TySpikeEventVec &spike_events) override
+	{
+		dbg_printf("NoInteractDt(): neuron_id = %d\n", neuron_id);
+		double spike_time_local = qNaN;
+		double *dym_val = StatePtr(neuron_id);
+		QUIET_STEP_CALL_INC();
+		neuron_models[neuron_id].NextStepSingleNeuronQuiet(
+			dym_val, time_in_refractory[neuron_id], spike_time_local, dt);
+		if (!std::isnan(spike_time_local)) {
+			spike_events.emplace_back(t_local + spike_time_local, neuron_id);
+		}
+	}
+
+	void SynapticInteraction(const TySpikeEvent &se) override
+	{
+		if (se.id < n_E) {
+			// Excitatory neuron fired
+			for (SparseMat::InnerIterator it(net, se.id); it; ++it) {
+				if (it.row() < n_E) {
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scee;
+				}
+				else {
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scie;
+				}
+			}
+		}
+		else {
+			// Inhibitory neuron fired
+			for (SparseMat::InnerIterator it(net, se.id); it; ++it) {
+				if (it.row() < n_E) {
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scei;
+				}
+				else {
+					dym_vals(it.row(), TyNeu::n_var + n_total() * 2 + se.id) += it.value() * scii;
+				}
+			}
+		}
+	}
+
+	void SynapticInteraction(int neuron_id, const int spike_from_id) override
+	{
+		if (spike_from_id < n_E) {
+			// Excitatory neuron fired
+			if (neuron_id < n_E) {
+				dym_vals(neuron_id, TyNeu::n_var + n_total() * 2 + neuron_id) += scee;
+			}
+			else {
+				dym_vals(neuron_id, TyNeu::n_var + n_total() * 2 + neuron_id) += scie;
+
+			}
+		}
+		else {
+			// Inhibitory neuron fired
+			if (neuron_id < n_E) {
+				dym_vals(neuron_id, TyNeu::n_var + n_total() * 3 + neuron_id) += scei;
+
+			}
+			else {
+				dym_vals(neuron_id, TyNeu::n_var + n_total() * 3 + neuron_id) += scii;
+
+			}
+		}
+	}
+
+	void ForceReset(int neuron_id) override
+	{
+		neuron_models[neuron_id].VoltHandReset(StatePtr(neuron_id));
+		time_in_refractory[neuron_id] = std::numeric_limits<double>::min();
+	}
+
+	void SetRefractoryTime(double t_ref) override
+	{
+		for (int i = 0; i < n_total(); i++) { neuron_models[i].Set_Time_Refractory(t_ref); }
+	}
+
+	void SetThreshold(double V_thres) override
+	{
+		for (int i = 0; i<n_total();i++) { neuron_models[i].V_threshold = V_thres; }
+	}
+
+	void DisableThreshold() override
+	{
+		SetThreshold(std::numeric_limits<double>::infinity());
+	}
+
+	void InjectPoissonE(int neuron_id) override
+	{
+		// Add Poisson input
+		dym_vals(neuron_id, TyNeu::id_gEPoisson) += arr_ps[neuron_id];
+	}
+
+	void InjectDeltaInput(int neuron_id, double strength) override
+	{
+		if (strength >= 0) {
+			dym_vals(neuron_id, TyNeu::id_gEPoisson) += strength;
+		}
+		else {
+			dym_vals(neuron_id, TyNeu::id_gIPoisson) -= strength;
+		}
+	}
+
+	const Ty_Neuron_Dym_Base * GetNeuronModel() const override
+	{
+		assert(0);
+		return &neuron_models[0];
+	}
+};
+
 #endif

--- a/neuron_system_utils.cpp
+++ b/neuron_system_utils.cpp
@@ -194,23 +194,48 @@ void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef
 
 	if (isNumber(name_coef)) {
 		double value = string2double(name_coef);
-		std::vector<double > onerow(n_neu, value);
-		std::vector<std::vector<double> > onemat(n_neu, onerow);
+		TyArrVals onerow(n_neu, value);
+		TyMatVals onemat(n_neu, onerow);
 
 		pm.alpha.resize(n_neu, onemat);
 
 	}
 	else {
-		std::ifstream fin_net(name_coef);
-		if (!fin_net) {
+		std::ifstream fin_alpha(name_coef);
+		if (!fin_alpha) {
 			cerr << "Fail to open file! \"" << name_coef << "\"" << endl;
 			throw "Fail to open file!\n";
 		}
 		if (!is_sparse) {
 			// Read network from text file
-			// TODO YWS
+			double a;
+			for (int i = 0; i < n_neu; i++) {
+				TyMatVals amat;
+
+				for (int j = 0; j < n_neu; j++) {
+					TyArrVals arow;
+					for (int k = 0; k < n_neu; k++) {
+						fin_alpha >> a;
+						if (j == k && a != 0) {
+							dbg_printf("Warning: in InitAlphaCoeffFromPath: it is unusual that alpha[i][i] to be nonzero. \n");
+						}
+						if (!std::isfinite(a)) {
+							dbg_printf("Warning: in InitAlphaCoeffFromPath: it is unusual that alpha[i][i] to be infinite. \n");
+						}
+						arow.push_back(a);
+					}
+					amat.push_back(arow);
+				}
+				pm.alpha.push_back(amat);
+			}
+
+			if (!fin_alpha) {
+				cerr << "Bad alpha coefficient file: \"" << name_coef << "\"\n";
+				throw "Bad alpha coefficient file!\n";
+			}
 		}
 		else {
+			printf("DIF-GH model doesn't suppport sparse net");
 			// TODO YWS
 
 		}

--- a/neuron_system_utils.cpp
+++ b/neuron_system_utils.cpp
@@ -230,7 +230,8 @@ void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef
 			}
 
 			if (!fin_alpha) {
-				cerr << "Bad alpha coefficient file: \"" << name_coef << "\"\n";
+				cerr << "Bad alpha coefficient file: \"" << name_coef << "\"\n"
+					<< " Notice that alpha coefficent file shall contain n*n*n doubles (n is the number of neurons)\n";
 				throw "Bad alpha coefficient file!\n";
 			}
 		}

--- a/neuron_system_utils.cpp
+++ b/neuron_system_utils.cpp
@@ -185,6 +185,7 @@ bool isNumber(std::string str) {
 	{
 		return false;
 	}
+	return true;
 }
 
 void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef, bool is_sparse)

--- a/neuron_system_utils.cpp
+++ b/neuron_system_utils.cpp
@@ -150,6 +150,74 @@ void FillNetFromPath(TyNeuronalParams &pm, const std::string &name_net,
   }
 }
 
+
+// YWS
+// credit to http://www.cplusplus.com/forum/general/42594/
+double string2double(const std::string& a)
+{
+	// Convert a string representation of a number into a floating point value.
+	// Throws an int if the string contains anything but whitespace and a valid
+	// numeric representation.
+	//
+	double result;
+	std::string s(a);
+
+	// Get rid of any trailing whitespace
+	s.erase(s.find_last_not_of(" \f\n\r\t\v") + 1);
+
+	// Read it into the target type
+	std::istringstream ss(s);
+	ss >> result;
+
+	// Check to see that there is nothing left over
+	if (!ss.eof())
+		throw 1;
+
+	return result;
+}
+
+bool isNumber(std::string str) {
+	try
+	{
+		string2double(str);
+	}
+	catch (int)
+	{
+		return false;
+	}
+}
+
+void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef, bool is_sparse)
+{
+	int n_neu = pm.n_total();
+
+	if (isNumber(name_coef)) {
+		double value = string2double(name_coef);
+		std::vector<double > onerow(n_neu, value);
+		std::vector<std::vector<double> > onemat(n_neu, onerow);
+
+		pm.alpha.resize(n_neu, onemat);
+
+	}
+	else {
+		std::ifstream fin_net(name_coef);
+		if (!fin_net) {
+			cerr << "Fail to open file! \"" << name_coef << "\"" << endl;
+			throw "Fail to open file!\n";
+		}
+		if (!is_sparse) {
+			// Read network from text file
+			// TODO YWS
+		}
+		else {
+			// TODO YWS
+
+		}
+
+	}
+}
+
+
 SparseMat ReadNetDelay(const std::string &dn_name, const SparseMat &net)
 {
   std::ifstream fin_net(dn_name);

--- a/neuron_system_utils.cpp
+++ b/neuron_system_utils.cpp
@@ -152,13 +152,13 @@ void FillNetFromPath(TyNeuronalParams &pm, const std::string &name_net,
 
 
 // YWS
+// TODO use strtod instead?
 // credit to http://www.cplusplus.com/forum/general/42594/
 double string2double(const std::string& a)
 {
 	// Convert a string representation of a number into a floating point value.
 	// Throws an int if the string contains anything but whitespace and a valid
 	// numeric representation.
-	//
 	double result;
 	std::string s(a);
 
@@ -188,6 +188,9 @@ bool isNumber(std::string str) {
 	return true;
 }
 
+
+// if the input string is a double, fill in the alpha(3d vector, vector<vector<vector<double> > >) with the double
+// otherwise, fill alpha from the path recogized in the input string
 void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef, bool is_sparse)
 {
 	int n_neu = pm.n_total();
@@ -237,6 +240,7 @@ void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef
 		}
 		else {
 			printf("DIF-GH model doesn't suppport sparse net");
+			exit(-101);
 			// TODO YWS
 
 		}

--- a/neuron_system_utils.h
+++ b/neuron_system_utils.h
@@ -23,6 +23,16 @@ struct TyNeuronalParams
   TyArrVals arr_pri;   // Poisson input rate for each neuron, I type.
   TyArrVals arr_psi;   // Poisson input strength for each neuron, I type.
 
+
+					   // Only for DIF
+					   // NOTICE: initialized by default constructor when copy
+					   // Alpha is determined by shunting coefficients
+					   // Alpha[l][i][j] means the effect of the pair of neuron (E,I) to the l-th neuron
+					   // where E is i-th exitory and I is the j-th inhibitory
+  std::vector<TyMatVals > alpha;
+  bool DIF_flag;	   // whether it's used in an non-simple DIF model
+					   // it will be initalized by default constructor when copy
+
   inline int n_total() const
   { return n_E + n_I; }
 
@@ -42,6 +52,8 @@ struct TyNeuronalParams
   :scee(0), scie(0), scei(0), scii(0)
   {
     SetNumberOfNeurons(_n_E, _n_I);
+	// NOTICE: alpha will be initialized by default constructor 
+	// not here because not all model need it
   }
 };
 
@@ -159,6 +171,8 @@ int FillTauG(TyNeuDymParam &dym_param, const char *path);
 
 void FillNetFromPath(TyNeuronalParams &pm, const std::string &name_net,
                      bool is_sparse);
+void InitAlphaCoeffFromPath(TyNeuronalParams & pm, const std::string & name_coef, 
+					 bool is_sparse);
 SparseMat ReadNetDelay(const std::string &dn_name, const SparseMat &net);
 int ReadSpikeList(TySpikeEventVec &spike_list, const char *path);
 

--- a/poisson_generator.h
+++ b/poisson_generator.h
@@ -30,6 +30,8 @@ public:
     rate = _rate;
     strength = _strength;
     t = t0;
+
+	if (rate == 0) rate = std::numeric_limits<double>::min();
     exp_dis = std::exponential_distribution<>(rate);
   }
 

--- a/single_neuron_dynamics.h
+++ b/single_neuron_dynamics.h
@@ -1179,7 +1179,7 @@ struct Ty_Hawkes_GH: public Ty_Neuron_Dym_Base
 //
 struct Ty_LIF_GH_single_dendritic_core
 {
-  // The neuron model named DIF-GH in this code.
+  // The neuron model named DIF-single-GH in this code.
   // This is the Leaky Integrate-and-Fire model with order 1 smoothed conductance. and the conductance has second order term.
   double V_threshold  = 1.0;  // voltages are in dimensionless unit
   double V_reset      = 0.0;
@@ -1275,5 +1275,343 @@ struct Ty_LIF_GH_single_dendritic_core
 };
 
 typedef Ty_LIF_stepper<Ty_LIF_GH_single_dendritic_core> Ty_DIF_single_GH;
+
+/////////////////////////////////////////////////////////////////////////////
+// Model of HH-GH with bilinear dentritic interaction
+
+struct Ty_DIF_GH_core
+{
+	// The neuron model named DIF-GH in this code.
+	// This is the Leaky Integrate-and-Fire model with order 1 smoothed conductance.
+	double V_threshold = 1.0;  // voltages are in dimensionless unit
+	double V_reset = 0.0;
+	double V_leakage = 0.0;
+	double V_excitatory = 14.0 / 3.0;
+	double V_inhibitory = -2.0 / 3.0;
+	double G_leak = 0.05;  // ms^-1
+	double tau_gE = 2.0;   // ms
+	double tau_gE_s1 = 0.5;   // ms
+	double tau_gI = 5.0;   // ms
+	double tau_gI_s1 = 0.8;   // ms
+	double Time_Refractory = 2.0;   // ms
+
+	TyMatVals* alpha;			 // coeffcients for dentritic interaction
+								 // it will be initialized in NeuronPopulationDendriticDeltaInteractTemplate
+
+	int n_neu;			 // number of neurons, it will be intialized in 
+								 // NeuronPopulationDendriticDeltaInteractTemplate and other similar classes
+	static const int n_var = 3;  // number of dynamical variables
+	static const int id_V = 0;   // index of V variable
+	static const int id_gEPoisson = 1; // index of conductance rlatinng to Poisson input
+	static const int id_gIPoisson = 2; // index of conductance rlatinng to Poisson input
+
+	// The following id shall be interpreted differentyl, since the there are a vector of gE, gI, etc
+	// id_x = n really means the data is stored continously in dymvals 
+	// from n_var + id_x * n_neu to n_var + (id_x + 1) * neu
+	static const int id_gE = 0;  // index bais coeff of gE variable
+	static const int id_gI = 1;  // index bias coeff of gI variable
+	static const int id_gE_s1 = 2;  // index bias coeff of derivative of gE
+	static const int id_gI_s1 = 3;  // index bias coeff of derivative of gI
+	static const int id_gEInject = id_gE_s1;  // index of bias coeff gE injection variable
+	static const int id_gIInject = id_gI_s1;  // index of bias coeff gI injection variable
+
+	// the real index of gE(etc) of the i-th neuron
+	inline int get_id_gE(int neuron_id) const { return n_var + n_neu * id_gE + neuron_id; }
+	inline int get_id_gI(int neuron_id) const { return n_var + n_neu * id_gI + neuron_id; }
+	inline int get_id_gE_s1(int neuron_id) const { return n_var + n_neu * id_gE_s1 + neuron_id; }
+	inline int get_id_gI_s1(int neuron_id) const { return n_var + n_neu * id_gI_s1 + neuron_id; }
+
+											  // Evolve conductance only
+	void NextDtConductance(double *dym_val, double dt) const
+	{
+		/**
+		ODE:
+		g '[t] == -1/tC  * g [t] + gR[t]
+		gR'[t] == -1/tCR * gR[t]
+		Solution:
+		g [t] = exp(-t/tC) * g[0] + (exp(-t/tC) - exp(-t/tCR)) * gR[0] * tC * tCR / (tC - tCR)
+		gR[t] = exp(-t/tCR) * gR[0]
+		Another form (hopefully more accurate, note exp(x)-1 is expm1(x) ):
+		g [t] = exp(-t/tC) * (g[0] + gR[0] * (exp((1/tC-1/tCR)*t) - 1) / (1/tC - 1/tCR))
+		Or
+		g [t] = exp(-t/tC) * g[0] + exp(-t/tCR) * gR[0] * (exp((1/tCR-1/tC)*t) - 1) / (1/tCR-1/tC)
+		*/
+		double expCE = exp(-dt / tau_gE);
+		double expCRE = exp(-dt / tau_gE_s1);
+
+		double expCI = exp(-dt / tau_gI);
+		double expCRI = exp(-dt / tau_gI_s1);
+
+		for (int i = 0; i < n_neu; i++) {
+			// exhibitory
+			dym_val[get_id_gE(i)] = expCE*dym_val[get_id_gE(i)] + (expCE - expCRE) * dym_val[get_id_gE_s1(i)] * tau_gE * tau_gE_s1 / (tau_gE - tau_gE_s1);
+			dym_val[get_id_gE_s1(i)] *= expCRE;
+			// inhibitory
+			dym_val[get_id_gI(i)] = expCI*dym_val[get_id_gI(i)] + (expCI - expCRI) * dym_val[get_id_gI_s1(i)] * tau_gI * tau_gI_s1 / (tau_gI - tau_gI_s1);
+			dym_val[get_id_gI_s1(i)] *= expCRI;
+		}
+	}
+
+	// Get instantaneous dv/dt for current dynamical state
+	inline double GetDv(const double *dym_val) const
+	{
+		double v_n = dym_val[id_V];
+
+
+		double retval = 0;
+		retval += G_leak * (v_n - V_leakage);
+
+		for (int i = 0; i < n_var; i++) {
+			retval += dym_val[get_id_gE(i)] * (v_n - V_excitatory);
+			retval += dym_val[get_id_gI(i)] * (v_n - V_inhibitory);
+
+		}
+		for (int i = 0; i < n_var; i++) {
+			for (int j = 0; j < n_var; j++) {
+				retval += alpha->at(i).at(j) * dym_val[get_id_gE(i)] * dym_val[get_id_gI(i)];  // *(V-V_excitatory)
+			}
+		}
+
+		return -retval;  // NOTE that in fact all terms are negative
+	}
+
+	// Evolve the state `dym_val' a `dt' forward,
+	// using classical Runge–Kutta 4-th order scheme for voltage.
+	// Conductance will evolve using the exact formula.
+	// Return derivative k1 at t_n, for later interpolation.
+	MACRO_NO_INLINE double DymInplaceRK4(double *dym_val, double dt) const
+	{
+		double v_n = dym_val[id_V];
+		double k1, k2, k3, k4;
+		double expEC = exp(-0.5 * dt / tau_gE);  // TODO: maybe cache this value?
+		double expECR = exp(-0.5 * dt / tau_gE_s1);
+		double expIC = exp(-0.5 * dt / tau_gI);
+		double expICR = exp(-0.5 * dt / tau_gI_s1);
+		double gE_s_coef = (expEC - expECR) * tau_gE * tau_gE_s1 / (tau_gE - tau_gE_s1);
+		double gI_s_coef = (expIC - expICR) * tau_gI * tau_gI_s1 / (tau_gI - tau_gI_s1);
+
+		// k1 = f(t_n, y_n)
+		k1 = GetDv(dym_val);
+
+		// y_n + 0.5*k1*dt
+		dym_val[id_V] = v_n + 0.5 * dt * k1;
+		for (int i = 0; i < n_neu; i++) {
+			dym_val[get_id_gE(i)] = expEC * dym_val[get_id_gE(i)] + gE_s_coef * dym_val[get_id_gE_s1(i)];
+			dym_val[get_id_gI(i)] = expIC * dym_val[get_id_gI(i)] + gI_s_coef * dym_val[get_id_gI_s1(i)];
+			dym_val[get_id_gE_s1(i)] *= expECR;
+			dym_val[get_id_gI_s1(i)] *= expICR;
+		}
+		// k2 = f(t+dt/2, y_n + 0.5*k1*dt)
+		k2 = GetDv(dym_val);
+
+		// y_n + 0.5*k2*dt
+		dym_val[id_V] = v_n + 0.5 * dt * k2;
+		// k3 = f(t+dt/2, y_n + 0.5*k2*dt)
+		k3 = GetDv(dym_val);
+
+		// y_n + k3*dt
+		dym_val[id_V] = v_n + dt * k3;
+		for (int i = 0; i < n_neu; i++) {
+			dym_val[get_id_gE(i)] = expEC * dym_val[get_id_gE(i)] + gE_s_coef * dym_val[get_id_gE_s1(i)];
+			dym_val[get_id_gI(i)] = expIC * dym_val[get_id_gI(i)] + gI_s_coef * dym_val[get_id_gI_s1(i)];
+			dym_val[get_id_gE_s1(i)] *= expECR;
+			dym_val[get_id_gI_s1(i)] *= expICR;
+		}
+		// k4 = f(t+dt, y_n + k3*dt)
+		k4 = GetDv(dym_val);
+
+		dym_val[id_V] = v_n + dt / 6.0 * (k1 + 2 * k2 + 2 * k3 + k4);
+
+		return k1;
+	}
+};
+
+// Adapter for DIF model (only sub-threshold dynamics and need hand reset)
+template<typename TyNeuronModel>
+struct Ty_DIF_stepper : public TyNeuronModel, public Ty_Neuron_Dym_Base
+{
+	// for template class we need these "using"s. It's a requirement for TyNeuronModel.
+	using TyNeuronModel::id_V;
+	//using TyNeuronModel::id_gE;
+	using TyNeuronModel::V_threshold;
+	using TyNeuronModel::V_reset;
+	using TyNeuronModel::Time_Refractory;
+	using TyNeuronModel::GetDv;
+	using TyNeuronModel::NextDtConductance;
+	//using TyNeuronModel::DymInplaceRK4;
+
+	//using TyNeuronModel::id_gEInject;
+	//using TyNeuronModel::id_gIInject;
+	using TyNeuronModel::n_var;
+	//using TyNeuronModel::id_gI;
+	// YWS the following is added for DIF
+	using TyNeuronModel::n_neu;
+
+	double Get_V_threshold() const override { return V_threshold; };
+	int Get_id_gEInject() const override { return n_var + n_neu * 2; assert(0); } // YWSTODO
+	int Get_id_gIInject() const override { return n_var + n_neu * 3; assert(0); }
+	int Get_n_dym_vars() const override { return n_var; }
+	int Get_id_V() const override { return id_V; }
+	int Get_id_gE() const override { return n_var; assert(0); }
+	int Get_id_gI() const override { return n_var + n_neu; assert(0); }
+
+	void Set_Time_Refractory(double t_ref) override
+	{
+		if (t_ref >= 0) {
+			Time_Refractory = t_ref;  // No error checking
+		}
+		else {
+			cerr << "Setting Time_Refractory < 0 : t_ref = " << t_ref << "\n";
+		}
+	}
+
+	// Used when reset the voltage by hand. (e.g. outside this class)
+	inline void VoltHandReset(double *dym_val) const override
+	{
+		dym_val[id_V] = V_reset;
+	}
+
+	// in fact, we never use it(? YWSQ )
+	void SpikeTimeRefine(double *dym_t, double &t_spike, int n_it, int n_E, int n_I) const
+	{
+		if (n_it == 1) {
+			DymInplaceRK4(dym_t, t_spike);
+			t_spike -= (dym_t[id_V] - V_threshold) / GetDv(dym_t);
+		}
+		else {  // multiple iterations
+			double dym_t0[n_var];
+			std::copy(dym_t, dym_t + n_var, dym_t0);  // copy of init state
+			for (int i = n_it - 1; i >= 0; i--) {
+				DymInplaceRK4(dym_t, t_spike);
+				/*t_spike -= (dym_t[id_V]-V_threshold) / GetDv(dym_t);*/
+				double dt_spike = (dym_t[id_V] - V_threshold) / GetDv(dym_t);
+				t_spike -= dt_spike;
+				dbg_printf("SpikeTimeRefine(): dt = %.17g, t_spike = %.17g, V = %.17g, Dv = %g\n",
+					dt_spike, t_spike, dym_t[id_V], GetDv(dym_t));
+				if (i) std::copy(dym_t0, dym_t0 + n_var, dym_t);
+			}
+		}
+	}
+
+	// Evolve the ODE and note down the spike time, assuming no reset and no external input.
+	// `spike_time_local' should be guaranteed to be within [0, dt] or NAN.
+	MACRO_NO_INLINE void NextStepSingleNeuronContinuous(double *dym_val, double &spike_time_local, double dt) const
+	{
+		double dym_t[n_var];
+		std::copy(dym_val, dym_val + n_var, dym_t);
+		double v_n = dym_val[id_V];						// the original V
+		double k1 = DymInplaceRK4(dym_val, dt);
+
+		// if there is a spike in this dt
+		if (v_n <= V_threshold							// the original V
+			&& dym_val[id_V] > V_threshold) {			// V, after evolve for dt
+			spike_time_local = cubic_hermit_real_root(dt,
+				v_n, dym_val[id_V],
+				k1, GetDv(dym_val), V_threshold);
+			// refine spike time
+			/*SpikeTimeRefine(dym_t, spike_time_local, 2);*/
+		}
+		else {
+			if (v_n > 0.996 && k1>0) { // the v_n > 0.996 is for dt=0.5 ms, LIF,G model
+									   // Try capture some missing spikes that the intermediate value passes
+									   // threshold, but both ends are lower than threshold.
+									   // Get quadratic curve from value of both ends and derivative from left end
+									   // Return the maximum point as `t_max_guess'
+				double c = v_n;
+				double b = k1;
+				double a = (dym_val[id_V] - c - b*dt) / (dt*dt);
+				double t_max_guess = -b / (2 * a);
+				// In LIF-G, it can guarantee that a<0 (concave),
+				// hence t_max_guess > 0. But in LIF-G model, we still need to
+				// check 0 < t_max_guess
+				if (0 < t_max_guess && t_max_guess < dt
+					&& (b*b) / (-4 * a) + c >= V_threshold) {
+					//dbg_printf("Rare event: mid-dt spike captured, guess time: %f\n", t_max_guess);
+					dbg_printf("NextStepSingleNeuronContinuous(): possible mid-dt spike detected:\n");
+					dbg_printf("  Guessed max time: %f, dt = %f\n", t_max_guess, dt);
+					// root should in [0, t_max_guess]
+					spike_time_local = cubic_hermit_real_root(dt,
+						v_n, dym_val[id_V],
+						k1, GetDv(dym_val), V_threshold);
+					/*SpikeTimeRefine(dym_t, spike_time_local, 2);*/
+				}
+				else {
+					spike_time_local = std::numeric_limits<double>::quiet_NaN();
+				}
+			}
+			else {
+				spike_time_local = std::numeric_limits<double>::quiet_NaN();
+			}
+		}
+	}
+
+	// Evolve single neuron as if no external input.
+	// Return first spike time in `spike_time_local', if any.
+	void NextStepSingleNeuronQuiet(double *dym_val, double &t_in_refractory,
+		double &spike_time_local, double dt_local) const override
+	{
+		//! at most one spike allowed during this dt_local
+		if (t_in_refractory == 0) {
+			dbg_printf("NextStepSingleNeuronQuiet(): dt_local = %.17g\n", dt_local);
+			dbg_printf("NextStepSingleNeuronQuiet(): begin state=%.16e,%.16e,%.16e\n",
+				dym_val[0], dym_val[1], dym_val[2]);
+			NextStepSingleNeuronContinuous(dym_val, spike_time_local, dt_local);
+			dbg_printf("NextStepSingleNeuronQuiet(): end   state=%.16e,%.16e,%.16e\n",
+				dym_val[0], dym_val[1], dym_val[2]);
+			if (!std::isnan(spike_time_local)) {
+				// Add `numeric_limits<double>::min()' to make sure t_in_refractory > 0.
+				t_in_refractory = dt_local - spike_time_local
+					+ std::numeric_limits<double>::min();
+				dym_val[id_V] = V_reset;
+				dbg_printf("NextStepSingleNeuronQuiet(): neuron fired, spike_time_local = %.17g\n", spike_time_local);
+				if (t_in_refractory >= Time_Refractory) {
+					// Short refractory period (< dt_local), neuron will be actived again.
+					dt_local = t_in_refractory - Time_Refractory;
+					t_in_refractory = 0;
+					// Back to the activation time.
+					NextDtConductance(dym_val, -dt_local);
+					double spike_time_local_tmp;
+					NextStepSingleNeuronContinuous(dym_val, spike_time_local_tmp, dt_local);
+					if (!std::isnan(spike_time_local_tmp)) {
+						cerr << "NextStepSingleNeuronQuiet(): Multiple spikes in one dt. Interaction dropped." << endl;
+						cerr << "  dt_local = " << dt_local << '\n';
+						cerr << "  spike_time_local = " << spike_time_local << '\n';
+						cerr << "  t_in_refractory = " << t_in_refractory << '\n';
+						cerr << "  dym_val[id_V] = " << dym_val[id_V] << '\n';
+						cerr << "  dym_val[id_gE] = " << dym_val[id_gE] << '\n';
+						throw "Multiple spikes in one dt.";
+					}
+				}
+			}
+		}
+		else {
+			// Neuron in refractory period.
+			double dt_refractory_remain = Time_Refractory
+				- t_in_refractory;
+			if (dt_refractory_remain < dt_local) {
+				// neuron will awake after dt_refractory_remain which is in this dt_local
+				NextDtConductance(dym_val, dt_refractory_remain);
+				assert(dym_val[id_V] == V_reset);
+				t_in_refractory = 0;
+				NextStepSingleNeuronQuiet(dym_val, t_in_refractory,
+					spike_time_local, dt_local - dt_refractory_remain);
+			}
+			else {
+				spike_time_local = std::numeric_limits<double>::quiet_NaN();
+				NextDtConductance(dym_val, dt_local);
+				t_in_refractory += dt_local;
+			}
+		}
+	}
+
+	const double * Get_dym_default_val() const
+	{
+		static const double dym[n_var] = { 0 };
+		return dym;
+	}
+};
+
+typedef Ty_DIF_stepper<Ty_DIF_GH_core> Ty_DIF_GH;
+
 
 #endif


### PR DESCRIPTION
This branch(?) implemented the bilinear dentritic interaction described in [1] in the frame of LIF-GH.

Changes includes:
### In single_neuorn_dynamics.h
add DIF_GH_core and DIF_stepper, adapted form LIF-GH and LIF_stepper.
Note that id_gE[_s1] id_gI[_s1] shall be interpreted differently, since there are n id_gE[_s1] or id_gI[_s1] 

###  In neuron_population.h
add NeuronPopulationBaseDendritic as the base class for DIF-* model ( for future use)

add NeuronPopulationDendriticDeltaInteractTemplate:  
Implement dentritic interaction when firing/ inputing evevnt  
Note that poisson input are injected into gE[I]Poisson_s1 and then influence gE[I]Poisson

###  In neuron_system_utils.h
In TyNeuronalParams:  
add vector<Tymatval> alpha to store alpha coefficients, which will be filled in in main.c by      initAlphaCoeffFromPath()  
add DIF_flag to indecate DIF-* model

### In  neuron_system_utils.cpp 
add InitAlphaCoeffFromPath()
if the input string is a double, fill in the alpha(3d vector, vector<vector<vector<double> > >) with the double, otherwise, fill alpha from the path recogized in the input string

### In main.c
adapt func_save_dym_values to output extra conductance in the case of DIF-GH
init alpha cofficients

[1]: Zhou D, Li S, Zhang X-h, Cai D (2013) Phenomenological Incorporation of Nonlinear Dendritic Integration Using Integrate-and-Fire Neuronal Frameworks. PLoS ONE 8(1): e53508. doi:10.1371/journal.pone.0053508
